### PR TITLE
Issue 145 fix enable to open unregistered workspace url

### DIFF
--- a/slackdeck/src/components/ColumnHeader.tsx
+++ b/slackdeck/src/components/ColumnHeader.tsx
@@ -244,22 +244,27 @@ export const ColumnHeader: React.FC<{
         if (slackUrlRegex.test(clipText)) {
           let inputUrl = clipText;
           // Convet URL
+          let is_breaked = false;
           for (let converter of props.slackUrlTable) {
             const workspaceUrlPattern = `^${converter.workspaceUrl}archives/`;
             const workspaceUrlRegex = new RegExp(workspaceUrlPattern);
             if (workspaceUrlRegex.test(inputUrl)) {
               inputUrl = convertWorkspaceUrlToClientUrl(converter.workspaceUrl, converter.clientUrl, inputUrl);
+              is_breaked = true;
               break;
             }
           }
+          if (is_breaked) {
+            // Save column
+            saveColumns(props.columnList);
 
-          // Save column
-          saveColumns(props.columnList);
-
-          // Open clipboard URL
-          let colElIdx = extractColumnIdxFromId(props.columnElement.getElementsByTagName('div')[0].id);
-          const _iframe = document.getElementsByClassName('col-iframe')[colElIdx] as HTMLIFrameElement;
-          _iframe.contentWindow.location.href = inputUrl;
+            // Open clipboard URL
+            let colElIdx = extractColumnIdxFromId(props.columnElement.getElementsByTagName('div')[0].id);
+            const _iframe = document.getElementsByClassName('col-iframe')[colElIdx] as HTMLIFrameElement;
+            _iframe.contentWindow.location.href = inputUrl;
+          } else {
+            setSnackBarOpen(true);
+          }
         } else {
           setSnackBarOpen(true);
         }

--- a/slackdeck/src/components/Deck.tsx
+++ b/slackdeck/src/components/Deck.tsx
@@ -17,6 +17,7 @@ import { Column } from './Column';
 import { DEFAULT_GENERAL_CONFIG, GeneralConfig } from '../shared/config';
 import { convertWorkspaceUrlToClientUrl, slackUrlRegex } from '../shared/slackUrlConverter';
 import { InvalidUrlSnackbar } from './InvalidUrlSnackbar';
+import { TryOutlined } from '@mui/icons-material';
 
 const AddSpeedDial: React.FC<{
   columnList: ColumnConfig[],
@@ -103,8 +104,24 @@ const AddSpeedDial: React.FC<{
       (clipText) => {
         setClipboardText(clipText);
         if (slackUrlRegex.test(clipText)) {
-          // Add column
-          addColumn(newColumnConfigForAddFromClipboard);
+          let inputUrl = clipText;
+          // Convet URL
+          let is_breaked = false;
+          for (let converter of props.generalConfig.slackUrlTable) {
+            const workspaceUrlPattern = `^${converter.workspaceUrl}archives/`;
+            const workspaceUrlRegex = new RegExp(workspaceUrlPattern);
+            if (workspaceUrlRegex.test(inputUrl)) {
+              inputUrl = convertWorkspaceUrlToClientUrl(converter.workspaceUrl, converter.clientUrl, inputUrl);
+              is_breaked = true;
+              break;
+            }
+          }
+          if (is_breaked) {
+            // Add column
+            addColumn(newColumnConfigForAddFromClipboard);
+          } else {
+            setSnackBarOpen(true);
+          }
         } else {
           setSnackBarOpen(true);
         }


### PR DESCRIPTION
Fixes #145

## 原因

- URL変換時に登録済URLのいずれにも該当しなかった場合の処理を書いていなかった

## 解決手段

- 上記の場合に、Snackbarを表示するよう修正