### PR TITLE
Issue 148 fix unsave column width

### DIFF
--- a/slackdeck/src/components/ColumnHeader.tsx
+++ b/slackdeck/src/components/ColumnHeader.tsx
@@ -7,7 +7,7 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ContentPasteGoIcon from '@mui/icons-material/ContentPasteGo';
-import { chooseColumnColor, ColumnConfig, columnDeleteButtonClassName, columnDeleteButtonId, columnDuplicateButtonClassName, columnDuplicateButtonId, columnElementId, columnIframeClassName, columnIframeId, columnMoveLeftButtonClassName, columnMoveLeftButtonId, columnMoveRightButtonClassName, columnMoveRightButtonId, columnOpenFromClipboardButtonClassName, columnOpenFromClipboardButtonId, COLUMN_WIDTH_OPTIONS_TEXT, extractColumnIdxFromId, saveColumns } from '../shared/column';
+import { chooseColumnColor, ColumnConfig, columnDeleteButtonClassName, columnDeleteButtonId, columnDuplicateButtonClassName, columnDuplicateButtonId, columnElementId, columnIframeClassName, columnIframeId, columnMoveLeftButtonClassName, columnMoveLeftButtonId, columnMoveRightButtonClassName, columnMoveRightButtonId, columnOpenFromClipboardButtonClassName, columnOpenFromClipboardButtonId, COLUMN_WIDTH_OPTIONS_TEXT, COLUMN_WIDTH_OPTIONS_VALUE, extractColumnIdxFromId, saveColumns } from '../shared/column';
 import ReactDOM from 'react-dom';
 import { Column } from './Column';
 import { convertWorkspaceUrlToClientUrl, SlackUrlConverter, slackUrlRegex } from '../shared/slackUrlConverter';
@@ -16,6 +16,7 @@ import { InvalidUrlSnackbar } from './InvalidUrlSnackbar';
 const ColumnWidthMenu: React.FC<{
   selectedColumnWidthOptionIndex: number,
   setSelectedColumnWidthOptionIndex: React.Dispatch<React.SetStateAction<number>>,
+  columnConfig: ColumnConfig,
 }> = (props) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [selectedIndex, setSelectedIndex] = React.useState<number>(props.selectedColumnWidthOptionIndex);
@@ -31,6 +32,7 @@ const ColumnWidthMenu: React.FC<{
   ) => {
     props.setSelectedColumnWidthOptionIndex(index);
     setSelectedIndex(index);
+    props.columnConfig.width = COLUMN_WIDTH_OPTIONS_VALUE[index];
     setAnchorEl(null);
   };
 
@@ -350,6 +352,7 @@ export const ColumnHeader: React.FC<{
             <ColumnWidthMenu
               selectedColumnWidthOptionIndex={props.selectedColumnWidthOptionIndex}
               setSelectedColumnWidthOptionIndex={props.setSelectedColumnWidthOptionIndex}
+              columnConfig={props.columnConfig}
             />
 
             {/* Delete buttion */}

--- a/slackdeck/src/components/ColumnHeader.tsx
+++ b/slackdeck/src/components/ColumnHeader.tsx
@@ -17,6 +17,7 @@ const ColumnWidthMenu: React.FC<{
   selectedColumnWidthOptionIndex: number,
   setSelectedColumnWidthOptionIndex: React.Dispatch<React.SetStateAction<number>>,
   columnConfig: ColumnConfig,
+  columnList: ColumnConfig[],
 }> = (props) => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const [selectedIndex, setSelectedIndex] = React.useState<number>(props.selectedColumnWidthOptionIndex);
@@ -33,6 +34,7 @@ const ColumnWidthMenu: React.FC<{
     props.setSelectedColumnWidthOptionIndex(index);
     setSelectedIndex(index);
     props.columnConfig.width = COLUMN_WIDTH_OPTIONS_VALUE[index];
+    saveColumns(props.columnList);
     setAnchorEl(null);
   };
 
@@ -353,6 +355,7 @@ export const ColumnHeader: React.FC<{
               selectedColumnWidthOptionIndex={props.selectedColumnWidthOptionIndex}
               setSelectedColumnWidthOptionIndex={props.setSelectedColumnWidthOptionIndex}
               columnConfig={props.columnConfig}
+              columnList={props.columnList}
             />
 
             {/* Delete buttion */}

--- a/slackdeck/src/components/Deck.tsx
+++ b/slackdeck/src/components/Deck.tsx
@@ -256,7 +256,6 @@ export const Deck: React.FC<{
     chrome.storage.sync.get(
       ['columnList', 'generalConfig'],
       function (value) {
-        console.log(value.columnList);
         if (value.columnList && value.generalConfig) {
           for (var i = 0; i < value.columnList.length; i++) {
             props.columnList[i] = value.columnList[i];
@@ -349,6 +348,7 @@ export const Deck: React.FC<{
           v{VERSION}
         </Typography>
       </div>
+      {console.log(props.columnList)}
     </div>
   )
 };


### PR DESCRIPTION
Fixes #148 

## 原因
- カラム幅変更時に `columnConfig` に変更を反映していなかった

## 解決手段
- `columnConfig` へ変更を反映するよう修正
- ついでにカラム幅変更時にカラム保存を実行するよう変更