### PR TITLE
🐛 #152 を修正

### DIFF
--- a/slackdeck/src/components/ColumnHeader.tsx
+++ b/slackdeck/src/components/ColumnHeader.tsx
@@ -34,7 +34,6 @@ const ColumnWidthMenu: React.FC<{
     props.setSelectedColumnWidthOptionIndex(index);
     setSelectedIndex(index);
     props.columnConfig.width = COLUMN_WIDTH_OPTIONS_VALUE[index];
-    saveColumns(props.columnList);
     setAnchorEl(null);
   };
 


### PR DESCRIPTION
Fixes #152 

## 原因
- `props.columnConfig` をsetState関数を用いずに更新していること？

## 解決手段
### 暫定
- カラム幅変更時にカラム保存を実行しないよう修正

### 恒久
- #154 で検討