### PR TITLE
Issue 176 bug no save columns

### DIFF
--- a/slackdeck/dist/manifest.json
+++ b/slackdeck/dist/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "SlackDeck",
     "description": "Arrange channels side-by-side",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "action": {
         "default_icon": "icon16.png",
         "default_popup": "popup.html"

--- a/slackdeck/src/components/Deck.tsx
+++ b/slackdeck/src/components/Deck.tsx
@@ -267,7 +267,7 @@ export const Deck: React.FC<{
     // Load
     chrome.storage.sync.get(
       ['columnList', 'generalConfig'], (value) => {
-        if (value.columnList && value.generalConfig) {
+        if (value.columnList) {
           for (var i = 0; i < value.columnList.length; i++) {
             props.columnList[i] = value.columnList[i];
           }
@@ -279,17 +279,19 @@ export const Deck: React.FC<{
               columnIndex={i}
               columnConfig={props.columnList[i]}
               columnElement={col}
-              slackUrlTable={value.generalConfig.slackUrlTable}
+              slackUrlTable={value.generalConfig ? value.generalConfig.slackUrlTable : generalConfig.slackUrlTable}
             />, col);
             document.getElementById("wrapper").appendChild(col);
           }
-          // For v1.0.0 update code
-          if (value.generalConfig.enableAutoSave === undefined) {
-            value.generalConfig.enableAutoSave = DEFAULT_GENERAL_CONFIG.enableAutoSave;
-          }
-          setGeneralConfig(value.generalConfig);
-          if (value.generalConfig.enableAutoSave) {
-            props.startAutoSave();
+          if (value.generalConfig) {
+            // For v1.0.0 update code
+            if (value.generalConfig.enableAutoSave === undefined) {
+              value.generalConfig.enableAutoSave = DEFAULT_GENERAL_CONFIG.enableAutoSave;
+            }
+            setGeneralConfig(value.generalConfig);
+            if (value.generalConfig.enableAutoSave) {
+              props.startAutoSave();
+            }
           }
           window.addEventListener('focus', rerenderDeck, false);
           window.addEventListener('blur', props.stopAutoSave, false);

--- a/slackdeck/src/shared/general.ts
+++ b/slackdeck/src/shared/general.ts
@@ -1,1 +1,1 @@
-export const VERSION = "1.0.0";
+export const VERSION = "1.0.1";


### PR DESCRIPTION
Fixes #176 

## 原因

1. 下記の行の if 文が `value.generalConfig` が undefined でせいで False になる
> https://github.com/yamamoto-yuta/slack-deck/blob/6cdeb40f0797b77165e048aec1d3565f91e650b0/slackdeck/src/components/Deck.tsx#LL270C47-L270C47

2. `generalConfig` には `DEFAULT_GENERAL_CONFIG` の値が入っているが、これは設定画面で APPLY ボタンを押さない限り Chrome 拡張機能には保存されない
3. そのため、 `value.generalConfig` は毎回 undefined になるので、先の if 文はずっと False
4. カラム復元処理は先の if 文が True のときしか実行されないので、このバグが発生した

## 解決手段

if 文の条件を修正した